### PR TITLE
Add `compile_timestamp.h`

### DIFF
--- a/docs/compile_date.md
+++ b/docs/compile_date.md
@@ -1,9 +1,11 @@
 
-# CompileDate.h
+# compile_date.h
+
 This repo provides header files that allow `C` and `C++` source
 files to generate integer representations of the compile date/time.
 
 These integer representations are `const` / `constexpr` compliant:
+
 * `__DATE_YEAR_INT__`
 * `__DATE_MONTH_INT__`
 * `__DATE_DAY_INT__`
@@ -13,11 +15,16 @@ These integer representations are `const` / `constexpr` compliant:
 * `__DATE_MSDOS_INT__`
 * `__TIME_MSDOS_INT__`
 
+The header also provides two `static const` null-termainated strings:
+
+* `__DATE_ISO8601_DATE__`, e.g., `"2022-12-25"`
+* `__DATE_ISO8601_DATETIME__`, e.g., `"2022-12-25T03:48:17"`
+
 As a silly example, this allows generation of code that will
 fail to compile on leap-days:
 
 ```C
-#include "compileDate.h"
+#include "compile_date.h"
 
 #if (__DATE_MONTH_INT__ == 2) && (__DATE_DAY_INT == 29)
   #error "Cannot compile on leap days"

--- a/docs/compile_timestamp.md
+++ b/docs/compile_timestamp.md
@@ -1,0 +1,36 @@
+
+# compile_timestamp.h
+
+This repo provides header files that allow `C` and `C++` source
+files to generate integer representations of the compile date/time.
+
+These integer representations are `const` / `constexpr` compliant:
+
+* `__TIMESTAMP_YEAR_INT__`
+* `__TIMESTAMP_MONTH_INT__`
+* `__TIMESTAMP_DAY_INT__`
+* `__TIMESTAMP_HOUR_INT__`
+* `__TIMESTAMP_MINUTE_INT__`
+* `__TIMESTAMP_SECONDS_INT__`
+* `__TIMESTAMP_MSDOS_DATE_INT__`
+* `__TIMESTAMP_MSDOS_TIME_INT__`
+
+The header also provides two `static const` null-termainated strings:
+
+* `__TIMESTAMP_ISO8601_DATE__`, e.g., `"2022-12-25"`
+* `__TIMESTAMP_ISO8601_DATETIME__`, e.g., `"2022-12-25T03:48:17"`
+
+As a silly example, this allows generation of code that will
+fail to compile if it was last modified on a leap-day:
+
+```C
+#include "compile_timestamp.h"
+
+#if (__DATE_MONTH_INT__ == 2) && (__DATE_DAY_INT == 29)
+  #error "Cannot compile on leap days"
+#endif
+```
+
+More usefully, it allows for things such as creating embedded filesystems
+to have a reasonable default date/time.  As an example, an early version
+of `compile_date.h` was used by Adafruit's implementation of [UF2](https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/661827c166989eeadbebe0ef7b4230793b678a4e/src/usb/uf2/ghostfat.c#L247-L254).

--- a/docs/compile_timestamp.md
+++ b/docs/compile_timestamp.md
@@ -26,7 +26,7 @@ fail to compile if it was last modified on a leap-day:
 ```C
 #include "compile_timestamp.h"
 
-#if (__DATE_MONTH_INT__ == 2) && (__DATE_DAY_INT == 29)
+#if (__TIMESTAMP_MONTH_INT__ == 2) && (__TIMESTAMP_DAY_INT__ == 29)
   #error "Cannot compile on leap days"
 #endif
 ```

--- a/docs/compile_timestamp.md
+++ b/docs/compile_timestamp.md
@@ -15,7 +15,7 @@ These integer representations are `const` / `constexpr` compliant:
 * `__TIMESTAMP_MSDOS_DATE_INT__`
 * `__TIMESTAMP_MSDOS_TIME_INT__`
 
-The header also provides two `static const` null-termainated strings:
+The header also provides two `static const` null-terminated strings:
 
 * `__TIMESTAMP_ISO8601_DATE__`, e.g., `"2022-12-25"`
 * `__TIMESTAMP_ISO8601_DATETIME__`, e.g., `"2022-12-25T03:48:17"`

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,9 @@ projects.  Each header has its own markdown file:
 * [compile_date.h](./src/compile_date.h) - Provides `constexpr` compliant
   macros to get integers corresponding to the compilate date / time.
   See [compile_date.md](./docs/compile_date.md) for more details.
+* [compile_timestamp.h](./src/compile_timestamp.h) - Provides `constexpr` compliant
+  macros to get integers corresponding to the file's last edited date / time.
+  See [compile_timestamp.md](./docs/compile_date.md) for more details.
 * [constexpr_strlen.h](./src/constexpr_strlen.h) - Provides `constexpr` compliant
   strlen for string literals via template function constexpr_strlen().
   See [constexpr_strlen.md](./docs/constexpr_strlen.md) for more details.

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ projects.  Each header has its own markdown file:
   See [compile_date.md](./docs/compile_date.md) for more details.
 * [compile_timestamp.h](./src/compile_timestamp.h) - Provides `constexpr` compliant
   macros to get integers corresponding to the file's last edited date / time.
-  See [compile_timestamp.md](./docs/compile_date.md) for more details.
+  See [compile_timestamp.md](./docs/compile_timestamp.md) for more details.
 * [constexpr_strlen.h](./src/constexpr_strlen.h) - Provides `constexpr` compliant
   strlen for string literals via template function constexpr_strlen().
   See [constexpr_strlen.md](./docs/constexpr_strlen.md) for more details.

--- a/src/compile_timestamp.h
+++ b/src/compile_timestamp.h
@@ -1,0 +1,173 @@
+#pragma once
+// see https://godbolt.org/z/1PjW637Mh
+
+/**
+
+The MIT License (MIT)
+
+Copyright (c) SimpleHacks, Henry Gabryjelski
+https://github.com/SimpleHacks/UtilHeaders
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#ifndef COMPILE_TIMESTAMP_H
+#define COMPILE_TIMESTAMP_H
+
+#ifndef __has_feature
+    #define __has_feature(x) 0 // Compatibility with non-clang compilers.
+#endif
+
+// This allows conditional declaration of the below as `constexpr`,
+// unless the compiler has not implemented the relevant feature.
+#if __cpp_constexpr >= 200704  || __has_feature(cxx_constexpr) // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf
+    #define __COMPILE_TIMESTAMP_H_CONSTEXPR constexpr
+#else
+    #define __COMPILE_TIMESTAMP_H_CONSTEXPR
+#endif    
+
+// GCC preprocess __TIMESTAMP__ to one of:
+//     "??? ??? ?? ??:??:?? ????" -- when last edit not determined
+//     "Sun Sep 16 01:03:52 1973" -- last edit of the file
+//      0....-....1....-....2...  -- indices to each character
+// Thus, must define error checks and define that return value when error.
+// Many options exist, including a unix tick of zero.  But, since this header
+// also supports DOS date & time (e.g., for FAT structures), chose the following:
+//     "Mon Jan  1 00:00:00 1980" -- What the macros effectively return on error
+
+#define __TIMESTAMP_FAILURE__ ( \
+  (__TIMESTAMP__ [ 0u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 1u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 2u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 3u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 4u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 5u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 6u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 7u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 8u] == '?') ? 1 : \
+  (__TIMESTAMP__ [ 9u] == '?') ? 1 : \
+  (__TIMESTAMP__ [10u] == '?') ? 1 : \
+  (__TIMESTAMP__ [11u] == '?') ? 1 : \
+  (__TIMESTAMP__ [12u] == '?') ? 1 : \
+  (__TIMESTAMP__ [13u] == '?') ? 1 : \
+  (__TIMESTAMP__ [14u] == '?') ? 1 : \
+  (__TIMESTAMP__ [15u] == '?') ? 1 : \
+  (__TIMESTAMP__ [16u] == '?') ? 1 : \
+  (__TIMESTAMP__ [17u] == '?') ? 1 : \
+  (__TIMESTAMP__ [18u] == '?') ? 1 : \
+  (__TIMESTAMP__ [19u] == '?') ? 1 : \
+  (__TIMESTAMP__ [20u] == '?') ? 1 : \
+  (__TIMESTAMP__ [21u] == '?') ? 1 : \
+  (__TIMESTAMP__ [22u] == '?') ? 1 : \
+  (__TIMESTAMP__ [23u] == '?') ? 1 : \
+  0 )
+#define __TIMESTAMP_YEAR_IMPL__ ((( \
+  (__TIMESTAMP__ [20u] - '0')  * 10u + \
+  (__TIMESTAMP__ [21u] - '0')) * 10u + \
+  (__TIMESTAMP__ [22u] - '0')) * 10u + \
+  (__TIMESTAMP__ [23u] - '0'))
+#define __TIMESTAMP_MONTH_IMPL__ ( \
+      (__TIMESTAMP__ [6u] == 'n' && __TIMESTAMP__ [5u] == 'a') ?  1u  /*Jan*/ \
+    : (__TIMESTAMP__ [6u] == 'b'                             ) ?  2u  /*Feb*/ \
+    : (__TIMESTAMP__ [6u] == 'r' && __TIMESTAMP__ [5u] == 'a') ?  3u  /*Mar*/ \
+    : (__TIMESTAMP__ [6u] == 'r'                             ) ?  4u  /*Apr*/ \
+    : (__TIMESTAMP__ [6u] == 'y'                             ) ?  5u  /*May*/ \
+    : (__TIMESTAMP__ [6u] == 'n'                             ) ?  6u  /*Jun*/ \
+    : (__TIMESTAMP__ [6u] == 'l'                             ) ?  7u  /*Jul*/ \
+    : (__TIMESTAMP__ [6u] == 'g'                             ) ?  8u  /*Aug*/ \
+    : (__TIMESTAMP__ [6u] == 'p'                             ) ?  9u  /*Sep*/ \
+    : (__TIMESTAMP__ [6u] == 't'                             ) ? 10u  /*Oct*/ \
+    : (__TIMESTAMP__ [6u] == 'v'                             ) ? 11u  /*Nov*/ \
+    :                                                            12u  /*Dec*/ )
+#define __TIMESTAMP_DAY_IMPL__ (( \
+   (__TIMESTAMP__ [8u] == ' ' ? 0u : __TIMESTAMP__ [8u] - '0') * 10u) + \
+   (__TIMESTAMP__ [9u] - '0')                                           )
+#define __TIMESTAMP_HOUR_IMPL__ (( \
+   (__TIMESTAMP__ [11u] - '0') * 10u) + \
+   (__TIMESTAMP__ [12u] - '0')          )
+#define __TIMESTAMP_MINUTE_IMPL__ (( \
+   (__TIMESTAMP__ [14u] - '0') * 10u) + \
+   (__TIMESTAMP__ [15u] - '0')          )
+#define __TIMESTAMP_SECONDS_IMPL__ (( \
+   (__TIMESTAMP__ [17u] - '0') * 10u) + \
+   (__TIMESTAMP__ [18u] - '0')          )
+#define __TIMESTAMP_MSDOS_DATE_IMPL__       ( \
+  ((__TIMESTAMP_YEAR_INT__  - 1980u) << 9u) | \
+  ( __TIMESTAMP_MONTH_INT__          << 5u) | \
+  ( __TIMESTAMP_DAY_INT__            << 0u) )
+#define __TIMESTAMP_MSDOS_TIME_IMPL__   ( \
+  ( __TIMESTAMP_HOUR_INT__      << 11u) | \
+  ( __TIMESTAMP_MINUTE_INT__    <<  5u) | \
+  ( __TIMESTAMP_SECONDS_INT__   <<  0u) )
+
+// And the resulting usable macros....
+#define __TIMESTAMP_YEAR_INT__       ( __TIMESTAMP_FAILURE__ ? 1980u : __TIMESTAMP_YEAR_IMPL__    )
+#define __TIMESTAMP_MONTH_INT__      ( __TIMESTAMP_FAILURE__ ?    1u : __TIMESTAMP_MONTH_IMPL__   )
+#define __TIMESTAMP_DAY_INT__        ( __TIMESTAMP_FAILURE__ ?    1u : __TIMESTAMP_DAY_IMPL__     )
+#define __TIMESTAMP_HOUR_INT__       ( __TIMESTAMP_FAILURE__ ?    0u : __TIMESTAMP_HOUR_IMPL__    )
+#define __TIMESTAMP_MINUTE_INT__     ( __TIMESTAMP_FAILURE__ ?    0u : __TIMESTAMP_MINUTE_IMPL__  )
+#define __TIMESTAMP_SECONDS_INT__    ( __TIMESTAMP_FAILURE__ ?    0u : __TIMESTAMP_SECONDS_IMPL__ )
+
+#define __TIMESTAMP_MSDOS_DATE_INT__ ( __TIMESTAMP_MSDOS_DATE_IMPL__ )
+#define __TIMESTAMP_MSDOS_TIME_INT__ ( __TIMESTAMP_MSDOS_TIME_IMPL__ )
+
+__COMPILE_TIMESTAMP_H_CONSTEXPR
+static const char __TIMESTAMP_ISO8601_DATE__[] =
+{
+    __TIMESTAMP_FAILURE__ ? '1' : (char)(( (__TIMESTAMP_YEAR_INT__    / 1000) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '9' : (char)(( (__TIMESTAMP_YEAR_INT__    /  100) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_YEAR_INT__    /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_YEAR_INT__    /    1) % 10 ) + '0'),
+    '-',
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_MONTH_INT__   /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_MONTH_INT__   /    1) % 10 ) + '0'),
+    '-',
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_DAY_INT__     /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_DAY_INT__     /    1) % 10 ) + '0'),
+    '\0'
+};
+
+__COMPILE_TIMESTAMP_H_CONSTEXPR
+const char __TIMESTAMP_ISO8601_DATETIME__[] =
+{
+    __TIMESTAMP_FAILURE__ ? '1' : (char)(( (__TIMESTAMP_YEAR_INT__    / 1000) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '9' : (char)(( (__TIMESTAMP_YEAR_INT__    /  100) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_YEAR_INT__    /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_YEAR_INT__    /    1) % 10 ) + '0'),
+    '-',
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_MONTH_INT__   /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_MONTH_INT__   /    1) % 10 ) + '0'),
+    '-',
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_DAY_INT__     /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_DAY_INT__     /    1) % 10 ) + '0'),
+    'T',
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_HOUR_INT__    /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_HOUR_INT__    /    1) % 10 ) + '0'),
+    ':',
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_MINUTE_INT__  /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_MINUTE_INT__  /    1) % 10 ) + '0'),
+    ':',
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_SECONDS_INT__ /   10) % 10 ) + '0'),
+    __TIMESTAMP_FAILURE__ ? '0' : (char)(( (__TIMESTAMP_SECONDS_INT__ /    1) % 10 ) + '0'),
+    '\0'
+};
+#endif // COMPILE_TIMESTAMP_H


### PR DESCRIPTION
And update documentation slightly.

Parses `__TIMESTAMP__` into corresponding strings and integers, 100% during compilation time.

Verified on:
* AVR GCC 4.5.4 ( compiles, C++)
* AVR GCC 9.2.0 ( compiles, C)
* x86 MSVC 19.20 ( executes )
* x86-64 clang 3.8 ( executes, C )
* x86-64 clang 3.3 ( executes, C++ )

Which is "good enough" in my book.